### PR TITLE
chore(Manifest) bump version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "GitHub PR Tool",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Mark all files as viewed / not viewed in GitHub pull requests.",
   "permissions": ["activeTab"],
   "action": {


### PR DESCRIPTION
## Pull Request Overview

This PR bumps the version number from 0.1.2 to 0.1.3 in the manifest.json file for the GitHub PR Tool extension.

- Version increment from 0.1.2 to 0.1.3