### PR TITLE
feat(Popup) display progress bar with file count

### DIFF
--- a/assets/css/popup.css
+++ b/assets/css/popup.css
@@ -174,6 +174,51 @@ h1 {
   width: 0.7rem;
 }
 
+/* Progress bar */
+
+.progress-container {
+  margin-top: 0.75rem;
+  text-align: center;
+}
+
+.progress-container[hidden] {
+  display: none;
+}
+
+.progress-text {
+  font-size: 12px;
+  color: var(--text);
+  margin-bottom: 0.25rem;
+  display: block;
+}
+
+.progress-bar {
+  height: 6px;
+  background-color: var(--btn-border);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  width: 0;
+  background-color: var(--btn-check-bg);
+  border-radius: 3px;
+  transition: width 0.2s ease;
+}
+
+.progress-container.done .progress-fill {
+  animation: blink 0.8s ease;
+}
+
+@keyframes blink {
+  0% { opacity: 1; }
+  25% { opacity: 0.3; }
+  50% { opacity: 1; }
+  75% { opacity: 0.3; }
+  100% { opacity: 1; }
+}
+
 /* Report issue link */
 
 .report-issue-link {

--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -23,11 +23,16 @@ chrome.runtime.onMessage.addListener(async (request) => {
     .join(', ')
 
   if (selector) {
-    await processElements(selector, signal)
+    const total = document.querySelectorAll(selector).length
+    chrome.runtime.sendMessage({ type: 'progress', processed: 0, total })
+    await processElements(selector, signal, 6, (processed) => {
+      chrome.runtime.sendMessage({ type: 'progress', processed, total })
+    })
+    chrome.runtime.sendMessage({ type: 'done', total })
   }
 })
 
-async function processElements(selector, signal, maxRetries = 6) {
+async function processElements(selector, signal, maxRetries = 6, onProgress) {
   let processed = 0
   let attempt = 0
   while (attempt < maxRetries) {
@@ -47,12 +52,13 @@ async function processElements(selector, signal, maxRetries = 6) {
         el.click()
         el.setAttribute('data-gprt-processed', '1')
         clickedThisRound++
+        processed++
+        onProgress?.(processed)
         await delay(150)
       } catch {
         // ignore errors to continue
       }
     }
-    processed += clickedThisRound
     if (clickedThisRound === 0) break
     attempt++
     await delay(300)

--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -23,12 +23,14 @@ chrome.runtime.onMessage.addListener(async (request) => {
     .join(', ')
 
   if (selector) {
-    const total = document.querySelectorAll(selector).length
-    chrome.runtime.sendMessage({ type: 'progress', processed: 0, total })
+    const countTotal = () =>
+      document.querySelectorAll(selector).length +
+      document.querySelectorAll('[data-gprt-processed="1"]').length
+    chrome.runtime.sendMessage({ type: 'progress', processed: 0, total: countTotal() })
     await processElements(selector, signal, 6, (processed) => {
-      chrome.runtime.sendMessage({ type: 'progress', processed, total })
+      chrome.runtime.sendMessage({ type: 'progress', processed, total: countTotal() })
     })
-    chrome.runtime.sendMessage({ type: 'done', total })
+    chrome.runtime.sendMessage({ type: 'done' })
   }
 })
 

--- a/assets/js/popup.js
+++ b/assets/js/popup.js
@@ -13,6 +13,22 @@ document.addEventListener('DOMContentLoaded', () => {
   addClickListener('check-all-files-btn', 'checkAll')
   addClickListener('uncheck-all-files-btn', 'uncheckAll')
 
+  const progressContainer = document.getElementById('progress-container')
+  const progressText = document.getElementById('progress-text')
+  const progressFill = document.getElementById('progress-fill')
+
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.type === 'progress') {
+      progressContainer.hidden = false
+      progressContainer.classList.remove('done')
+      progressText.textContent = `${message.processed}/${message.total} files`
+      const percent = message.total > 0 ? (message.processed / message.total) * 100 : 0
+      progressFill.style.width = `${percent}%`
+    } else if (message.type === 'done') {
+      progressContainer.classList.add('done')
+    }
+  })
+
   chrome.storage.local.get('updateNotification').then((result) => {
     const notification = result.updateNotification
     if (!notification) return

--- a/popup.html
+++ b/popup.html
@@ -41,6 +41,12 @@
       </svg>
       Uncheck all files
     </button>
+    <div id="progress-container" class="progress-container" hidden>
+      <span id="progress-text" class="progress-text"></span>
+      <div class="progress-bar">
+        <div id="progress-fill" class="progress-fill"></div>
+      </div>
+    </div>
     <a
       href="https://github.com/8Thomas8/github-pr-tool-chrome-extension/issues"
       target="_blank"


### PR DESCRIPTION
close #29 
  - Display processed/total file count in the popup during check/uncheck actions
  - Add a progress bar with blink animation on completion
  - Compute total dynamically to handle GitHub's lazy-loaded file diffs