### PR TITLE
fix(Popup) fix file count and tweak ui

### DIFF
--- a/assets/css/popup.css
+++ b/assets/css/popup.css
@@ -4,10 +4,12 @@
   --text: #24292e;
 
   --btn-text: #ffffff;
-  --btn-border: #1f232826;
+  --btn-focus-ring: #0969da;
 
   --btn-check-bg: #2da44e;
   --btn-uncheck-bg: #cf222e;
+
+  --progress-track: #d0d7de;
 
   --report-link: #2b7fff;
   --report-link-hover: #2b55ff;
@@ -23,6 +25,9 @@
     --text: #c9d1d9;
 
     --btn-text: #ffffff;
+    --btn-focus-ring: #58a6ff;
+
+    --progress-track: #30363d;
 
     --report-link: #8b949e;
     --report-link-hover: #c9d1d9;
@@ -40,10 +45,7 @@ body {
   align-items: stretch;
   background-color: var(--bg);
   padding: 0.75rem;
-  font-family:
-    'Fira Sans',
-    system-ui,
-    sans-serif;
+  font-family: 'Fira Sans', system-ui, sans-serif;
   text-align: center;
   color: var(--text);
 }
@@ -52,7 +54,6 @@ h1 {
   color: var(--text);
   font-size: 15px;
   font-weight: 600;
-  letter-spacing: -0.01em;
   margin: 0.5rem 0 1rem;
 }
 
@@ -143,6 +144,12 @@ h1 {
   opacity: 1;
 }
 
+.dismiss-update-btn:focus-visible {
+  outline: 2px solid var(--btn-focus-ring);
+  outline-offset: 1px;
+  opacity: 1;
+}
+
 .dismiss-update-btn svg {
   fill: currentColor;
   height: 0.7rem;
@@ -164,12 +171,30 @@ h1 {
   font-size: 12px;
   color: var(--text);
   margin-bottom: 0.25rem;
-  display: block;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.progress-text svg {
+  fill: var(--btn-check-bg);
+  height: 0.8rem;
+  width: 0.8rem;
+  opacity: 0;
+  transform: scale(0.6);
+  transition:
+    opacity 0.25s ease,
+    transform 0.25s ease;
+}
+
+.progress-container.done .progress-text svg {
+  opacity: 1;
+  transform: scale(1);
 }
 
 .progress-bar {
   height: 8px;
-  background-color: var(--btn-border);
+  background-color: var(--progress-track);
   border-radius: 3px;
   overflow: hidden;
 }
@@ -179,19 +204,17 @@ h1 {
   width: 0;
   background-color: var(--btn-check-bg);
   border-radius: 3px;
-  transition: width 0.2s ease;
+  transition:
+    width 0.2s ease,
+    background-color 0.15s ease;
 }
 
-.progress-container.done .progress-fill {
-  animation: blink 0.5s ease;
+.progress-container.is-uncheck .progress-fill {
+  background-color: var(--btn-uncheck-bg);
 }
 
-@keyframes blink {
-  0% { opacity: 1; }
-  25% { opacity: 0.3; }
-  50% { opacity: 1; }
-  75% { opacity: 0.3; }
-  100% { opacity: 1; }
+.progress-container.is-uncheck .progress-text svg {
+  fill: var(--btn-uncheck-bg);
 }
 
 /* Report issue link */
@@ -203,9 +226,15 @@ h1 {
   margin-top: 0.75rem;
   text-decoration: none;
   align-self: center;
+  border-radius: 3px;
 }
 
 .report-issue-link:hover {
   text-decoration: underline;
   color: var(--report-link-hover);
+}
+
+.report-issue-link:focus-visible {
+  outline: 2px solid var(--btn-focus-ring);
+  outline-offset: 2px;
 }

--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -26,52 +26,45 @@ if (!window.__gprtContentLoaded) {
       .join(', ')
 
     if (selector) {
-      const countTotal = () =>
-        document.querySelectorAll(selector).length +
-        document.querySelectorAll('[data-gprt-processed="1"]').length
-      chrome.runtime.sendMessage({ type: 'progress', processed: 0, total: countTotal() })
-      await processElements(selector, signal, 6, (processed) => {
-        chrome.runtime.sendMessage({ type: 'progress', processed, total: countTotal() })
+      await processElements(selector, signal, 6, (processed, total) => {
+        chrome.runtime.sendMessage({ type: 'progress', processed, total })
       })
       chrome.runtime.sendMessage({ type: 'done' })
     }
   })
 
-  async function processElements(selector, signal, maxRetries = 6, onProgress) {
-    let processed = 0
-    let attempt = 0
-    while (attempt < maxRetries) {
-      if (signal.aborted) break
+  async function processElements(selector, signal, maxRetries, onProgress) {
+    const targets = new Set()
+    const done = new Set()
+    const discover = () => document.querySelectorAll(selector).forEach((el) => targets.add(el))
 
-      const seen = new Set()
-      const elements = [...document.querySelectorAll(selector)].filter(
-        (el) => !seen.has(el) && seen.add(el)
-      )
+    discover()
+    onProgress(0, targets.size)
 
-      if (elements.length === 0) break
-      let clickedThisRound = 0
-      for (const el of elements) {
-        if (signal.aborted) break
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      if (signal.aborted) return
+
+      discover()
+      const pending = [...targets].filter((el) => !done.has(el) && el.isConnected)
+      if (pending.length === 0) return
+
+      let clicked = 0
+      for (const el of pending) {
+        if (signal.aborted) return
         try {
           el.scrollIntoView({ behavior: 'auto', block: 'center' })
           el.click()
-          el.setAttribute('data-gprt-processed', '1')
-          clickedThisRound++
-          processed++
-          onProgress?.(processed)
+          done.add(el)
+          clicked++
+          onProgress(done.size, targets.size)
           await delay(150)
         } catch {
           // ignore errors to continue
         }
       }
-      if (clickedThisRound === 0) break
-      attempt++
+      if (clicked === 0) return
       await delay(300)
     }
-    document
-      .querySelectorAll('[data-gprt-processed="1"]')
-      .forEach((el) => el.removeAttribute('data-gprt-processed'))
-    return processed
   }
 
   function delay(ms) {

--- a/assets/js/popup.js
+++ b/assets/js/popup.js
@@ -1,8 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const progressContainer = document.getElementById('progress-container')
+  const progressLabel = document.getElementById('progress-label')
+  const progressFill = document.getElementById('progress-fill')
+
   const addClickListener = (btnId, action) => {
     const btn = document.getElementById(btnId)
     if (btn) {
       btn.addEventListener('click', () => {
+        progressContainer.classList.remove('done')
+        progressContainer.classList.toggle('is-uncheck', action === 'uncheckAll')
         chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
           const tabId = tabs[0]?.id
           if (!tabId) return
@@ -27,15 +33,11 @@ document.addEventListener('DOMContentLoaded', () => {
   addClickListener('check-all-files-btn', 'checkAll')
   addClickListener('uncheck-all-files-btn', 'uncheckAll')
 
-  const progressContainer = document.getElementById('progress-container')
-  const progressText = document.getElementById('progress-text')
-  const progressFill = document.getElementById('progress-fill')
-
   chrome.runtime.onMessage.addListener((message) => {
     if (message.type === 'progress') {
       progressContainer.hidden = false
       progressContainer.classList.remove('done')
-      progressText.textContent = `${message.processed}/${message.total} files`
+      progressLabel.textContent = `${message.processed}/${message.total} files`
       const percent = message.total > 0 ? (message.processed / message.total) * 100 : 0
       progressFill.style.width = `${percent}%`
     } else if (message.type === 'done') {

--- a/popup.html
+++ b/popup.html
@@ -22,7 +22,12 @@
         </svg>
         <span><strong id="update-version"></strong> - See what's new</span>
       </a>
-      <button id="dismiss-update-btn" class="dismiss-update-btn" title="Dismiss" aria-label="Dismiss">
+      <button
+        id="dismiss-update-btn"
+        class="dismiss-update-btn"
+        title="Dismiss"
+        aria-label="Dismiss"
+      >
         <svg aria-hidden="true" viewBox="0 0 16 16" version="1.1">
           <path
             d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"
@@ -36,7 +41,14 @@
       <button id="uncheck-all-files-btn" class="btn btn-uncheck-all">Uncheck all</button>
     </div>
     <div id="progress-container" class="progress-container" hidden>
-      <span id="progress-text" class="progress-text"></span>
+      <span id="progress-text" class="progress-text">
+        <svg aria-hidden="true" viewBox="0 0 16 16" version="1.1">
+          <path
+            d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"
+          />
+        </svg>
+        <span id="progress-label"></span>
+      </span>
       <div class="progress-bar">
         <div id="progress-fill" class="progress-fill"></div>
       </div>


### PR DESCRIPTION
  - Fix the file counter showing inaccurate totals during check/uncheck operations by tracking targets and processed elements in Sets instead of relying on DOM data
  attributes that were re-counted each tick.
  - Replace the end-of-run blink animation with a checkmark icon that fades in next to the counter, and color the progress bar red when running "Uncheck all" to match the
  action.
  - Minor a11y/UX polish: focus-visible outlines on the dismiss and "report issue" controls, smoother progress-bar transition, cleanup of unused CSS variables.

close #52 