### PR TITLE
fix(Naming): rename extension to Tickhub

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
-# TikHub Chrome Extension
+# Tickhub Chrome Extension
 
-TikHub is a Chrome browser extension that streamlines the process of marking all files as viewed or unviewed in GitHub pull requests. The extension adds a convenient popup interface with buttons to check or uncheck all files in a pull request.
+Tickhub is a Chrome browser extension that streamlines the process of marking all files as viewed or unviewed in GitHub pull requests. The extension adds a convenient popup interface with buttons to check or uncheck all files in a pull request.
 
 **Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.**
 
@@ -99,7 +99,7 @@ Before committing changes, always run these exact commands that the CI pipeline 
 ### Preparing for Distribution
 
 1. Ensure all changes are committed and tested
-2. Run `make zip` to create `tikhub-chrome-extension.zip`
+2. Run `make zip` to create `tickhub-chrome-extension.zip`
 3. The zip file contains all necessary files for Chrome Web Store upload
 4. Run `make clean` to remove the zip file after upload
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Changelog
 
-## [1.0.0](https://github.com/8Thomas8/tikhub-chrome-extension/compare/0.1.11...1.0.0) (2026-06-09)
+## [1.0.0](https://github.com/8Thomas8/tickhub-chrome-extension/compare/0.1.11...1.0.0) (2026-06-09)
 
 
 ### ⚠ BREAKING CHANGES
 
-* Rebranded the extension to **TikHub** ([#56](https://github.com/8Thomas8/tikhub-chrome-extension/pull/56)).
+* Rebranded the extension to **Tickhub** ([#56](https://github.com/8Thomas8/tickhub-chrome-extension/pull/56)).
 
 
 ### Miscellaneous Chores
 
-* Set up automated releases with release-please and zip upload ([#57](https://github.com/8Thomas8/tikhub-chrome-extension/pull/57)).
-* Drop the `v` prefix from release tags to match the existing scheme ([#58](https://github.com/8Thomas8/tikhub-chrome-extension/pull/58)).
-* Enforce conventional-commit PR titles in CI ([#59](https://github.com/8Thomas8/tikhub-chrome-extension/pull/59)).
+* Set up automated releases with release-please and zip upload ([#57](https://github.com/8Thomas8/tickhub-chrome-extension/pull/57)).
+* Drop the `v` prefix from release tags to match the existing scheme ([#58](https://github.com/8Thomas8/tickhub-chrome-extension/pull/58)).
+* Enforce conventional-commit PR titles in CI ([#59](https://github.com/8Thomas8/tickhub-chrome-extension/pull/59)).

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Name of the zip
-EXT_NAME = tikhub-chrome-extension
+EXT_NAME = tickhub-chrome-extension
 ZIP_FILE = $(EXT_NAME).zip
 
 # Folders and files to include

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Overview
 
-TikHub is a Chrome extension designed to streamline the process of marking all files as viewed in GitHub pull
+Tickhub is a Chrome extension designed to streamline the process of marking all files as viewed in GitHub pull
 requests. It adds a convenient interface to easily check or uncheck all files in a pull request.
 
 🔗 **_Chrome Webstore link : https://chrome.google.com/webstore/detail/github-pr-tool/ibfdkipjpbbpmjgfknefhabhbgkkaode_**

--- a/assets/js/popup.js
+++ b/assets/js/popup.js
@@ -56,7 +56,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!container || !link || !versionEl || !dismissBtn) return
 
     versionEl.textContent = `v${notification.version}`
-    link.href = `https://github.com/8Thomas8/tikhub-chrome-extension/releases/tag/${notification.version}`
+    link.href = `https://github.com/8Thomas8/tickhub-chrome-extension/releases/tag/${notification.version}`
     container.hidden = false
 
     link.addEventListener('click', () => {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "TikHub",
+  "name": "Tickhub",
   "version": "1.0.0",
   "description": "Mark all files as viewed / not viewed in GitHub pull requests.",
   "permissions": [
@@ -14,7 +14,7 @@
   "action": {
     "default_popup": "popup.html",
     "default_icon": "assets/images/icon.png",
-    "default_title": "TikHub - Click to mark all files as viewed or not viewed."
+    "default_title": "Tickhub - Click to mark all files as viewed or not viewed."
   },
   "icons": {
     "48": "assets/images/icon.png"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "name": "tikhub",
+  "name": "tickhub",
   "scripts": {
     "lint": "eslint .",
     "format": "prettier --write ."

--- a/popup.html
+++ b/popup.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>TikHub</title>
+    <title>Tickhub</title>
     <script src="assets/js/popup.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -35,7 +35,7 @@
         </svg>
       </button>
     </div>
-    <h1>TikHub</h1>
+    <h1>Tickhub</h1>
     <div class="btn-group">
       <button id="check-all-files-btn" class="btn btn-check-all">Check all</button>
       <button id="uncheck-all-files-btn" class="btn btn-uncheck-all">Uncheck all</button>
@@ -54,7 +54,7 @@
       </div>
     </div>
     <a
-      href="https://github.com/8Thomas8/tikhub-chrome-extension/issues"
+      href="https://github.com/8Thomas8/tickhub-chrome-extension/issues"
       target="_blank"
       rel="noopener noreferrer"
       class="report-issue-link"


### PR DESCRIPTION
Rename TikHub → Tickhub across the extension (display name, package, Makefile, URLs/slug, docs).